### PR TITLE
Improve order polling logic and persistence

### DIFF
--- a/src/database/supabase_schema.sql
+++ b/src/database/supabase_schema.sql
@@ -80,3 +80,8 @@ CREATE TABLE public.order_item_option (
   CONSTRAINT order_item_option_order_item_id_fkey FOREIGN KEY (order_item_id) REFERENCES public.order_item(order_item_id),
   CONSTRAINT order_item_option_option_item_id_fkey FOREIGN KEY (option_item_id) REFERENCES public.option_item(option_item_id)
 );
+
+CREATE TABLE IF NOT EXISTS cache_meta (
+  key text PRIMARY KEY,
+  value text
+);

--- a/src/gui/order_widget.py
+++ b/src/gui/order_widget.py
@@ -23,15 +23,13 @@ class OrderWidget(QWidget):
         self.setup_ui()
         self.orders = []
 
-        # 새로운 주문 감지용 타이머
-        self.poll_timer = QTimer()
-        self.poll_timer.timeout.connect(self.check_new_orders)
-        self.poll_timer.start(5000)  # 5초 간격
+        # 주문 갱신을 위한 단일 타이머
+        self.update_timer = QTimer()
+        self.update_timer.timeout.connect(self.check_for_updates)
+        self.update_timer.start(5000)
 
-        # 주기적으로 주문 목록 갱신
-        self.refresh_timer = QTimer()
-        self.refresh_timer.timeout.connect(self.refresh_orders)
-        self.refresh_timer.start(5000)  # 5초마다 갱신
+        # 초기 주문 로드
+        self.refresh_orders()
         
     def setup_ui(self):
         # 메인 레이아웃
@@ -185,11 +183,13 @@ class OrderWidget(QWidget):
         except Exception as e:
             QMessageBox.warning(self, "오류", f"동기화 중 오류가 발생했습니다: {str(e)}")
 
-    def check_new_orders(self):
-        """새로운 주문 발생 여부를 확인하고 알림"""
+    def check_for_updates(self):
+        """새 주문을 확인하고 필요한 경우 목록을 갱신"""
         try:
             if self.cache.poll_new_orders():
-                self.notice_label.setText("새 주문이 있습니다. 새로고침해주세요.")
+                self.refresh_orders()
+            else:
+                self.notice_label.setText("")
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary
- use `contextlib.suppress` for SQLite setup
- persist `last_order_id` across runs via new `cache_meta` table
- merge refresh and polling timers into one
- load orders on startup

## Testing
- `ruff check src/database/cache.py src/gui/order_widget.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'escpos')*

------
https://chatgpt.com/codex/tasks/task_e_684d7d46e95c832d9d10ca3a9ecce82a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Order tracking now persists the last processed order across sessions for improved reliability.
- **Improvements**
	- Streamlined order update checks by consolidating periodic refresh and new order detection into a single process, resulting in more efficient and timely updates.
- **Bug Fixes**
	- Enhanced error handling during database setup for smoother operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->