### PR TITLE
Improve error visibility for order polling

### DIFF
--- a/src/gui/order_widget.py
+++ b/src/gui/order_widget.py
@@ -9,6 +9,7 @@ from PySide6.QtWidgets import (
     QMessageBox,
 )
 from PySide6.QtCore import Qt, Slot, QTimer
+import logging
 
 from ..database.cache import SupabaseCache
 
@@ -190,6 +191,7 @@ class OrderWidget(QWidget):
         try:
             if self.cache.poll_new_orders():
                 self.notice_label.setText("새 주문이 있습니다. 새로고침해주세요.")
-        except Exception:
-            pass
+        except Exception as e:
+            logging.error(f"Error while polling new orders: {e}")
+            self.notice_label.setText("주문 확인 중 오류가 발생했습니다.")
 


### PR DESCRIPTION
## Summary
- log polling errors in `OrderWidget.check_new_orders`
- display notice label when polling fails

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'escpos')*

------
https://chatgpt.com/codex/tasks/task_e_684d7d68ed38832d869f7537c1484e3b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling when checking for new orders, providing users with a notification if an error occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->