### PR TITLE
Implement auto print basics

### DIFF
--- a/src/auto_print.py
+++ b/src/auto_print.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+from datetime import time
+
+class OrderStatus:
+    """주문 출력 상태 값"""
+    NEW = "신규"
+    PRINTING = "출력중"
+    PRINTED = "출력완료"
+    PRINT_FAILED = "출력실패"
+
+@dataclass
+class PrintSettings:
+    """자동 출력 동작을 제어하는 설정"""
+    auto_print_enabled: bool = True
+    print_retry_count: int = 3
+    print_retry_interval: int = 30  # seconds
+    business_hours_start: time = time(0, 0)
+    business_hours_end: time = time(23, 59)
+    print_dine_in_only: bool = False

--- a/src/database/sqlite_schema.sql
+++ b/src/database/sqlite_schema.sql
@@ -60,6 +60,9 @@ CREATE TABLE IF NOT EXISTS "order" (
   total_price INTEGER DEFAULT 0,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   is_printed INTEGER DEFAULT 0,
+  print_status TEXT DEFAULT '신규',
+  print_attempts INTEGER DEFAULT 0,
+  last_print_attempt TIMESTAMP,
   FOREIGN KEY (company_id) REFERENCES company(company_id)
 );
 

--- a/src/database/supabase_schema.sql
+++ b/src/database/supabase_schema.sql
@@ -59,6 +59,9 @@ CREATE TABLE public.order (
   total_price integer DEFAULT 0,
   created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
   is_printed boolean DEFAULT false,
+  print_status text,
+  print_attempts integer,
+  last_print_attempt timestamp without time zone,
   CONSTRAINT order_pkey PRIMARY KEY (order_id),
   CONSTRAINT order_company_id_fkey FOREIGN KEY (company_id) REFERENCES public.company(company_id)
 );


### PR DESCRIPTION
## Summary
- add `OrderStatus` and `PrintSettings` dataclass for auto print control
- extend SQLite schema with print status fields
- expose update method in cache for print status
- integrate auto-print logic into `OrderWidget`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685098b229b4832db064d05294e3d62e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced automatic order printing with configurable settings, including retry attempts, business hours, and dine-in order restriction.
  - Added real-time print status tracking and display for each order.
  - Integrated print retry logic for failed print attempts, with status updates and scheduling.
- **Bug Fixes**
  - Improved order status display to reflect detailed print lifecycle states.
- **Chores**
  - Updated database schemas to support print status, attempt count, and last attempt timestamp for orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->