### PR TITLE
Fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*.*.*'  # v1.0.0 같이 버전 태그를 push할 때만 작동
 
+permissions:
+  contents: write
+
 jobs:
   build-and-release:
     runs-on: windows-latest


### PR DESCRIPTION
## Summary
- allow GitHub Actions to create releases

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863dd848b3c832d9365c6166cd59c63