### PR TITLE
Fix time zone handling for orders

### DIFF
--- a/src/gui/order_widget.py
+++ b/src/gui/order_widget.py
@@ -725,12 +725,16 @@ class OrderWidget(QWidget):
             # 주문일시
             created_at = order_data.get("created_at", "")
             if created_at:
-                # ISO 형식의 날짜를 한국 시간으로 변환하여 표시
-                from datetime import datetime
+                # ISO 형식의 날짜를 한국 시간(KST)으로 변환하여 표시
+                from datetime import datetime, timezone
+                from zoneinfo import ZoneInfo
                 try:
                     dt = datetime.fromisoformat(created_at.replace('Z', '+00:00'))
+                    if dt.tzinfo is None:
+                        dt = dt.replace(tzinfo=timezone.utc)
+                    dt = dt.astimezone(ZoneInfo("Asia/Seoul"))
                     created_at = dt.strftime("%Y-%m-%d %H:%M:%S")
-                except:
+                except Exception:
                     pass
             self.order_table.setItem(row_position, 7, QTableWidgetItem(created_at))
             


### PR DESCRIPTION
## Summary
- display order times in KST within the order widget
- print receipts with order time and print time adjusted to KST

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688166261308832db18a389d423f3395